### PR TITLE
fix: read GIT_HASH and BUILD_TIMESTAMP at build time

### DIFF
--- a/packages/core/src/api/tauri/debug.rs
+++ b/packages/core/src/api/tauri/debug.rs
@@ -73,13 +73,13 @@ impl TauriLauncherDebugApi for TauriLauncherDebugApiImpl {
 		version().to_string()
 	}
 
-	async fn get_commit_hash(self) -> LauncherResult<String> {
-		let hash = std::env::var("GIT_HASH").map_err(anyhow::Error::from)?;
+	async fn get_commit_hash(self) -> LauncherResult<&'static str> {
+		let hash = option_env!("GIT_HASH").unwrap_or("null");
 		Ok(hash)
 	}
 
-	async fn get_build_timestamp(self) -> LauncherResult<String> {
-		let timestamp = std::env::var("BUILD_TIMESTAMP").map_err(anyhow::Error::from)?;
+	async fn get_build_timestamp(self) -> LauncherResult<&'static str> {
+		let timestamp = option_env!("BUILD_TIMESTAMP").unwrap_or("null");
 		Ok(timestamp)
 	}
 }


### PR DESCRIPTION
ref https://discord.com/channels/616186924390023171/1446838860460855316

i assume this is not exactly like you want it to be, feel free to correct it (or ask me to do it :P ).
I opted for option_env! over env! as i assume this will only be set in CI or in whatever special circumstances.
I also chose to return "null" if it's unset but we can also keep returning an error in which case we'd have to change the frontend to not panic so much on errors there (as shown in the linked thread)

p.s. this is targetting your refactor/cleanup branch :)